### PR TITLE
refactor: root manager dequeue function

### DIFF
--- a/packages/deployments/contracts/contracts/messaging/RootManager.sol
+++ b/packages/deployments/contracts/contracts/messaging/RootManager.sol
@@ -100,6 +100,13 @@ contract RootManager is ProposedOwnable, IRootManager, WatcherClient, DomainInde
    */
   event ProposedRootFinalized(bytes32 aggregateRoot);
 
+  /**
+   * @notice Emitted when an aggregate root is added to the validAggregateRoots map.
+   * @param aggregateRoot The aggregate root finalized
+   * @param rootTimestamp The timestamp at which the aggregate root was saved.
+   */
+  event AggregateRootSaved(bytes32 aggregateRoot, uint256 rootTimestamp);
+
   // ============ Errors ============
 
   error RootManager_proposeAggregateRoot__InvalidSnapshotId(uint256 snapshotId);
@@ -677,6 +684,10 @@ contract RootManager is ProposedOwnable, IRootManager, WatcherClient, DomainInde
     // aggregate root and count).
     (bytes32 _aggregateRoot, uint256 _count) = MERKLE.insert(_verifiedInboundRoots);
 
+    validAggregateRoots[block.timestamp] = _aggregateRoot;
+    lastSavedAggregateRootTimestamp = block.timestamp;
+
+    emit AggregateRootSaved(_aggregateRoot, block.timestamp);
     emit RootsAggregated(_aggregateRoot, _count, _verifiedInboundRoots);
 
     return (_aggregateRoot, _count);

--- a/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
@@ -1510,7 +1510,14 @@ contract RootManager_Dequeue is Base {
 
     vm.expectCall(_merkle, abi.encodeWithSelector(insertSelector, _verifiedInboundRoots));
 
+    uint256 _expectedRootTimestamp = block.timestamp;
+    bytes32 _beforeRoot = _rootManager.validAggregateRoots(_expectedRootTimestamp);
+
     _rootManager.dequeue();
+
+    bytes32 _afterRoot = _rootManager.validAggregateRoots(_expectedRootTimestamp);
+
+    assertNotEq(_beforeRoot, _afterRoot);
   }
 
   function test_saveNewAggregateRoot(bytes32 aggregateRoot) public {

--- a/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
@@ -138,6 +138,8 @@ contract Base is ForgeHelper {
 
   event PropagateFailed(uint32 domain, address connector);
 
+  event AggregateRootSaved(bytes32 aggregateRoot, uint256 rootTimestamp);
+
   // ============ Storage ============
   RootManagerForTest _rootManager;
   uint256 _delayBlocks = 40;
@@ -1440,5 +1442,106 @@ contract RootManager_FinalizeAndPropagate is Base {
 contract RootManager_GetSnapshotDuration is Base {
   function test_getSnapshotDuration() public {
     assertEq(SnapshotId.SNAPSHOT_DURATION, _rootManager.getSnapshotDuration());
+  }
+}
+
+contract RootManager_Dequeue is Base {
+  bytes32 INBOUND = 0x0000000000000000000000000000000000000000000000000000000000000001;
+
+  bytes4 insertSelector = bytes4(keccak256("insert(bytes32[])"));
+
+  uint256 mockedCount = 1;
+
+  function test_nothingToDequeueReturnsSameRoot() public {
+    bytes32 _beforeRoot = MerkleTreeManager(_merkle).root();
+
+    (bytes32 _afterRoot, ) = _rootManager.dequeue();
+
+    assertEq(_beforeRoot, _afterRoot);
+  }
+
+  function test_callMerkleManagerInsert() public {
+    _rootManager.forTest_addInboundRootToQueue(INBOUND);
+
+    // fastforward blocks to make the element in the queue ready.
+    vm.roll(block.number + _rootManager.delayBlocks());
+
+    bytes32[] memory _verifiedInboundRoots = new bytes32[](1);
+    _verifiedInboundRoots[0] = INBOUND;
+
+    vm.expectCall(_merkle, abi.encodeWithSelector(insertSelector, _verifiedInboundRoots));
+
+    _rootManager.dequeue();
+  }
+
+  function test_saveNewAggregateRoot(bytes32 aggregateRoot) public {
+    _rootManager.forTest_addInboundRootToQueue(INBOUND);
+
+    // fastforward blocks to make the element in the queue ready.
+    vm.roll(block.number + _rootManager.delayBlocks());
+
+    // Mock the call over `insert`
+    vm.mockCall(_merkle, abi.encodeWithSelector(insertSelector), abi.encode(aggregateRoot, mockedCount));
+
+    uint256 _lastSavedRootTimestamp = block.timestamp;
+
+    _rootManager.dequeue();
+
+    bytes32 _root = _rootManager.validAggregateRoots(_lastSavedRootTimestamp);
+
+    assertEq(_root, aggregateRoot);
+  }
+
+  function test_updateLastSavedRootTimestamp(bytes32 aggregateRoot) public {
+    _rootManager.forTest_addInboundRootToQueue(INBOUND);
+
+    // fastforward blocks to make the element in the queue ready.
+    vm.roll(block.number + _rootManager.delayBlocks());
+
+    // Mock the call over `insert`
+    vm.mockCall(_merkle, abi.encodeWithSelector(insertSelector), abi.encode(aggregateRoot, mockedCount));
+
+    uint256 _expectedRootTimestamp = block.timestamp;
+
+    _rootManager.dequeue();
+
+    uint256 _lastSavedRootTimestamp = _rootManager.lastSavedAggregateRootTimestamp();
+
+    assertEq(_lastSavedRootTimestamp, _expectedRootTimestamp);
+  }
+
+  function test_emitIfAggregateRootSaved(bytes32 aggregateRoot) public {
+    _rootManager.forTest_addInboundRootToQueue(INBOUND);
+
+    // fastforward blocks to make the element in the queue ready.
+    vm.roll(block.number + _rootManager.delayBlocks());
+
+    // Mock the call over `insert`
+    vm.mockCall(_merkle, abi.encodeWithSelector(insertSelector), abi.encode(aggregateRoot, mockedCount));
+
+    uint256 _expectedSavedTimestamp = block.timestamp;
+
+    vm.expectEmit(true, true, true, true);
+    emit AggregateRootSaved(aggregateRoot, _expectedSavedTimestamp);
+
+    _rootManager.dequeue();
+  }
+
+  function test_emitIfRootsAggregated(bytes32 aggregateRoot) public {
+    _rootManager.forTest_addInboundRootToQueue(INBOUND);
+
+    // fastforward blocks to make the element in the queue ready.
+    vm.roll(block.number + _rootManager.delayBlocks());
+
+    bytes32[] memory _verifiedInboundRoots = new bytes32[](1);
+    _verifiedInboundRoots[0] = INBOUND;
+
+    // Mock the call over `insert`
+    vm.mockCall(_merkle, abi.encodeWithSelector(insertSelector), abi.encode(aggregateRoot, mockedCount));
+
+    vm.expectEmit(true, true, true, true);
+    emit RootsAggregated(aggregateRoot, mockedCount, _verifiedInboundRoots);
+
+    _rootManager.dequeue();
   }
 }

--- a/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
@@ -1485,7 +1485,7 @@ contract RootManager_GetSnapshotDuration is Base {
 }
 
 contract RootManager_Dequeue is Base {
-  bytes32 INBOUND = 0x0000000000000000000000000000000000000000000000000000000000000001;
+  bytes32 RANDOM_INBOUND_ROOT = bytes32("random inbound root");
 
   bytes4 insertSelector = bytes4(keccak256("insert(bytes32[])"));
 
@@ -1500,13 +1500,13 @@ contract RootManager_Dequeue is Base {
   }
 
   function test_callMerkleManagerInsert() public {
-    _rootManager.forTest_addInboundRootToQueue(INBOUND);
+    _rootManager.forTest_addInboundRootToQueue(RANDOM_INBOUND_ROOT);
 
     // fastforward blocks to make the element in the queue ready.
     vm.roll(block.number + _rootManager.delayBlocks());
 
     bytes32[] memory _verifiedInboundRoots = new bytes32[](1);
-    _verifiedInboundRoots[0] = INBOUND;
+    _verifiedInboundRoots[0] = RANDOM_INBOUND_ROOT;
 
     vm.expectCall(_merkle, abi.encodeWithSelector(insertSelector, _verifiedInboundRoots));
 
@@ -1514,7 +1514,7 @@ contract RootManager_Dequeue is Base {
   }
 
   function test_saveNewAggregateRoot(bytes32 aggregateRoot) public {
-    _rootManager.forTest_addInboundRootToQueue(INBOUND);
+    _rootManager.forTest_addInboundRootToQueue(RANDOM_INBOUND_ROOT);
 
     // fastforward blocks to make the element in the queue ready.
     vm.roll(block.number + _rootManager.delayBlocks());
@@ -1532,7 +1532,7 @@ contract RootManager_Dequeue is Base {
   }
 
   function test_updateLastSavedRootTimestamp(bytes32 aggregateRoot) public {
-    _rootManager.forTest_addInboundRootToQueue(INBOUND);
+    _rootManager.forTest_addInboundRootToQueue(RANDOM_INBOUND_ROOT);
 
     // fastforward blocks to make the element in the queue ready.
     vm.roll(block.number + _rootManager.delayBlocks());
@@ -1550,7 +1550,7 @@ contract RootManager_Dequeue is Base {
   }
 
   function test_emitIfAggregateRootSaved(bytes32 aggregateRoot) public {
-    _rootManager.forTest_addInboundRootToQueue(INBOUND);
+    _rootManager.forTest_addInboundRootToQueue(RANDOM_INBOUND_ROOT);
 
     // fastforward blocks to make the element in the queue ready.
     vm.roll(block.number + _rootManager.delayBlocks());
@@ -1567,13 +1567,13 @@ contract RootManager_Dequeue is Base {
   }
 
   function test_emitIfRootsAggregated(bytes32 aggregateRoot) public {
-    _rootManager.forTest_addInboundRootToQueue(INBOUND);
+    _rootManager.forTest_addInboundRootToQueue(RANDOM_INBOUND_ROOT);
 
     // fastforward blocks to make the element in the queue ready.
     vm.roll(block.number + _rootManager.delayBlocks());
 
     bytes32[] memory _verifiedInboundRoots = new bytes32[](1);
-    _verifiedInboundRoots[0] = INBOUND;
+    _verifiedInboundRoots[0] = RANDOM_INBOUND_ROOT;
 
     // Mock the call over `insert`
     vm.mockCall(_merkle, abi.encodeWithSelector(insertSelector), abi.encode(aggregateRoot, mockedCount));

--- a/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
@@ -140,6 +140,8 @@ contract Base is ForgeHelper {
 
   event AggregateRootSaved(bytes32 aggregateRoot, uint256 rootTimestamp);
 
+  event ProposedRootFinalized(bytes32 aggregateRoot);
+
   // ============ Storage ============
   RootManagerForTest _rootManager;
   uint256 _delayBlocks = 40;
@@ -605,9 +607,6 @@ contract RootManager_ProposeAggregateRoot is Base {
 }
 
 contract RootManager_Finalize is Base {
-  event AggregateRootSaved(bytes32 aggregateRoot, uint256 rootTimestamp);
-  event ProposedRootFinalized(bytes32 aggregateRoot);
-
   function test_revertIfSlowModeOn() public {
     _rootManager.forTest_setOptimisticMode(false);
 


### PR DESCRIPTION
Refactor the `dequeue` function to make it save the new `aggregate root` on the mapping `validAggregateRoots` and also update the new variable `lastSavedAggregateRootTimestamp`.

CLOSES CON3-5