### PR TITLE
refactor: unify propagate

### DIFF
--- a/packages/deployments/contracts/contracts/messaging/RootManager.sol
+++ b/packages/deployments/contracts/contracts/messaging/RootManager.sol
@@ -74,7 +74,7 @@ contract RootManager is ProposedOwnable, IRootManager, WatcherClient, DomainInde
    * @param aggregateRoot The aggregate root propagated
    * @param domainsHash The current domain hash
    */
-  event OptimisticRootPropagated(bytes32 indexed aggregateRoot, bytes32 domainsHash);
+  event AggregateRootPropagated(bytes32 indexed aggregateRoot, bytes32 domainsHash);
 
   /**
    * @notice Emitted when a new aggregate root is proposed
@@ -127,10 +127,6 @@ contract RootManager is ProposedOwnable, IRootManager, WatcherClient, DomainInde
 
   error RootManager_onlyProposer__NotWhitelistedProposer(address caller);
 
-  error RootManager_optimisticPropagate__ForbiddenOptimisticRoot();
-
-  error RootManager_slowPropagate__OldAggregateRoot();
-
   error RootManager_sendRootToHub__NoMessageSent();
 
   error RootManager_finalize__InvalidInputHash();
@@ -179,7 +175,7 @@ contract RootManager is ProposedOwnable, IRootManager, WatcherClient, DomainInde
    * After switching back to slow mode, if the count didnt change from previous slow mode, we consider the root as an old one since
    * probably lot of optimistic roots have been propagated.
    * Example: Propagation in slow mode happens, switch to Op Mode, multiple propagations happen, switch back to Slow mode.
-   * If at this point someone calls propagate and the queue is empty or non of elemenets are ready, _slowPropagate will
+   * If at this point someone calls propagate and the queue is empty or non of elemenets are ready, propagate will
    * call the dequeue function which will return the old root and count before Op mode was activated. And since multiple
    * propagations happened while in optimistic mode, the lastPropagatedRoot will be different than the old but current MERKLE.root
    * which will lead to propagating a deprecated root.
@@ -510,29 +506,13 @@ contract RootManager is ProposedOwnable, IRootManager, WatcherClient, DomainInde
    * @notice This is called by relayers to take the current aggregate tree root and propagate it to all
    * spoke domains (via their respective hub connectors).
    * @dev Should be called by relayers at a regular interval.
-   * Workflow is different depending on the mode the system is in.
+   * Workflow is slightly different depending on the mode the system is in.
    *
    * @param _connectors Array of connectors: should match exactly the array of `connectors` in storage;
    * used here to reduce gas costs, and keep them static regardless of number of supported domains.
    * @param _fees Array of fees in native token for an AMB if required
    * @param _encodedData Array of encodedData: extra params for each AMB if required
    */
-  function propagate2(
-    address[] calldata _connectors,
-    uint256[] calldata _fees,
-    bytes[] memory _encodedData
-  ) public payable whenNotPaused {
-    validateConnectors(_connectors);
-
-    uint256 _numDomains = _connectors.length;
-    // Sanity check: fees and encodedData lengths matches connectors length.
-    require(_fees.length == _numDomains && _encodedData.length == _numDomains, "invalid lengths");
-
-    optimisticMode
-      ? _optimisticPropagate(_connectors, _fees, _encodedData)
-      : _slowPropagate(_connectors, _fees, _encodedData);
-  }
-
   function propagate(
     address[] calldata _connectors,
     uint256[] calldata _fees,
@@ -549,63 +529,9 @@ contract RootManager is ProposedOwnable, IRootManager, WatcherClient, DomainInde
 
     bytes32 _aggregateRoot = validAggregateRoots[lastSavedAggregateRootTimestamp];
 
-    _sendRootToHubs(_aggregateRoot, _connectors, _fees, _encodedData);
-  }
-
-  /**
-   * @notice Function used to propagate the aggregate root when the system is in optimistic mode.
-   * @dev The root used is the already finalized optimistic root, this function does not use the MERKLE tree nor the
-   * pendingInboundRoots queue.
-   * Will set finalizedOptimisticAggregateRoot to FINALIZED_HASH.
-   * Emits a unique event.
-   * CRITICAL: This function does NOT check if _connectors sent to it are correct or not.
-   * Can always be called internally, since it doesn't check if the system is in optimistic mode or not.
-   * All the needed checks must be done before calling this function.
-   *
-   * @param _connectors Array of connectors: should match exactly the array of `connectors` in storage;
-   * used here to reduce gas costs, and keep them static regardless of number of supported domains.
-   * @param _fees Array of fees in native token for an AMB if required
-   * @param _encodedData Array of encodedData: extra params for each AMB if required
-   */
-  function _optimisticPropagate(
-    address[] calldata _connectors,
-    uint256[] calldata _fees,
-    bytes[] memory _encodedData
-  ) internal {
-    bytes32 _aggregateRoot = finalizedOptimisticAggregateRoot;
-    if (_aggregateRoot == FINALIZED_HASH) revert RootManager_optimisticPropagate__ForbiddenOptimisticRoot();
-
-    finalizedOptimisticAggregateRoot = FINALIZED_HASH;
+    emit AggregateRootPropagated(_aggregateRoot, domainsHash);
 
     _sendRootToHubs(_aggregateRoot, _connectors, _fees, _encodedData);
-    emit OptimisticRootPropagated(_aggregateRoot, domainsHash);
-  }
-
-  /**
-   * @notice Function used to propagate the aggregate root when the system is in slow mode.
-   * @dev Will dequeue the elements that are ready on pendingInboundRoots queue and insert them in MERKLE tree to generate
-   * the new aggregate root that needs to be propagated.
-   * Will set the finalizedOptimisticAggregateRoot to FINALIZE_HASH in order to discard an old root with old inboundRoots.
-   * Emits a unique event.
-   * CRITICAL: This function does NOT check if _connectors sent to it are correct or not.
-   * Can always be called internally, since it doesn't check if the system is in slow mode or not.
-   * All the needed checks must be done before calling this function.
-   *
-   * @param _connectors Array of connectors: should match exactly the array of `connectors` in storage;
-   * used here to reduce gas costs, and keep them static regardless of number of supported domains.
-   * @param _fees Array of fees in native token for an AMB if required
-   * @param _encodedData Array of encodedData: extra params for each AMB if required
-   */
-  function _slowPropagate(
-    address[] calldata _connectors,
-    uint256[] calldata _fees,
-    bytes[] memory _encodedData
-  ) internal {
-    finalizedOptimisticAggregateRoot = FINALIZED_HASH;
-    (bytes32 _aggregateRoot, uint256 _currentCount) = dequeue();
-    if (_currentCount <= lastCountBeforeOpMode) revert RootManager_slowPropagate__OldAggregateRoot();
-    _sendRootToHubs(_aggregateRoot, _connectors, _fees, _encodedData);
-    emit RootPropagated(_aggregateRoot, _currentCount, domainsHash);
   }
 
   /**

--- a/packages/deployments/contracts/contracts/messaging/RootManager.sol
+++ b/packages/deployments/contracts/contracts/messaging/RootManager.sol
@@ -517,7 +517,7 @@ contract RootManager is ProposedOwnable, IRootManager, WatcherClient, DomainInde
    * @param _fees Array of fees in native token for an AMB if required
    * @param _encodedData Array of encodedData: extra params for each AMB if required
    */
-  function propagate(
+  function propagate2(
     address[] calldata _connectors,
     uint256[] calldata _fees,
     bytes[] memory _encodedData
@@ -533,7 +533,7 @@ contract RootManager is ProposedOwnable, IRootManager, WatcherClient, DomainInde
       : _slowPropagate(_connectors, _fees, _encodedData);
   }
 
-  function propagate2(
+  function propagate(
     address[] calldata _connectors,
     uint256[] calldata _fees,
     bytes[] memory _encodedData

--- a/packages/deployments/contracts/contracts/messaging/RootManager.sol
+++ b/packages/deployments/contracts/contracts/messaging/RootManager.sol
@@ -175,7 +175,7 @@ contract RootManager is ProposedOwnable, IRootManager, WatcherClient, DomainInde
    * After switching back to slow mode, if the count didnt change from previous slow mode, we consider the root as an old one since
    * probably lot of optimistic roots have been propagated.
    * Example: Propagation in slow mode happens, switch to Op Mode, multiple propagations happen, switch back to Slow mode.
-   * If at this point someone calls propagate and the queue is empty or non of elemenets are ready, propagate will
+   * If at this point someone calls propagate and the queue is empty or non of the elements are ready, propagate will
    * call the dequeue function which will return the old root and count before Op mode was activated. And since multiple
    * propagations happened while in optimistic mode, the lastPropagatedRoot will be different than the old but current MERKLE.root
    * which will lead to propagating a deprecated root.
@@ -524,7 +524,7 @@ contract RootManager is ProposedOwnable, IRootManager, WatcherClient, DomainInde
     // Sanity check: fees and encodedData lengths matches connectors length.
     require(_fees.length == _numDomains && _encodedData.length == _numDomains, "invalid lengths");
 
-    // If in slow mode, we still dequeue to ensure that we add the inboundRoots that are ready.
+    // If in slow mode, we dequeue to ensure that we add the inboundRoots that are ready.
     if (!optimisticMode) dequeue();
 
     bytes32 _aggregateRoot = validAggregateRoots[lastSavedAggregateRootTimestamp];

--- a/packages/deployments/contracts/contracts_forge/messaging/ProposeFinalizePropagate.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/ProposeFinalizePropagate.t.sol
@@ -101,7 +101,7 @@ contract ProposeFinalizePropagate is ForgeHelper {
     isSlow();
 
     // Should revert because no new messages have arrived
-    vm.expectRevert(abi.encodeWithSelector(RootManager.RootManager_slowPropagate__OldAggregateRoot.selector));
+    vm.expectRevert(abi.encodeWithSelector(RootManager.RootManager_sendRootToHub__NoMessageSent.selector));
 
     // Propagate
     rootManager.propagate(connectors, fees, encodedData);
@@ -180,13 +180,13 @@ contract ProposeFinalizePropagate is ForgeHelper {
   }
 
   function test_RootManager__QueuedDequeueQueuedSwitch() external {
-    // Start in slowMode
     vm.mockCall(
       watcherManager,
       abi.encodeWithSelector(WatcherManager(watcherManager).isWatcher.selector),
       abi.encode(true)
     );
     vm.prank(watcher);
+    // Set in slowMode
     rootManager.activateSlowMode();
 
     // Checks that we are in slow mode

--- a/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
@@ -1110,6 +1110,30 @@ contract RootManager_Propagate is Base {
   }
 }
 
+contract RootManager_Propagate2 is Base {
+  function test_revertIfContractPaused() public {
+    _rootManager.forTest_pause();
+    vm.expectRevert(bytes("Pausable: paused"));
+    _rootManager.propagate(_connectors, _fees, _encodedData);
+  }
+
+  function test_revertIfInvalidLengthsIfDifferentFeesAmounts(uint256[] calldata randomFees) public {
+    vm.assume(randomFees.length != _connectors.length);
+    _rootManager.forTest_generateAndAddDomains(_domains, _connectors);
+
+    vm.expectRevert(bytes("invalid lengths"));
+    _rootManager.propagate(_connectors, randomFees, _encodedData);
+  }
+
+  function test_revertIfInvalidLengthsIfDifferentDatasAmounts(bytes[] calldata randomEncodedData) public {
+    vm.assume(randomEncodedData.length != _connectors.length);
+    _rootManager.forTest_generateAndAddDomains(_domains, _connectors);
+
+    vm.expectRevert(bytes("invalid lengths"));
+    _rootManager.propagate(_connectors, _fees, randomEncodedData);
+  }
+}
+
 contract RootManager_OptimisticPropagate is Base {
   event OptimisticRootPropagated(bytes32 indexed aggregateRoot, bytes32 domainsHash);
 

--- a/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/RootManager.t.sol
@@ -1097,6 +1097,10 @@ contract RootManager_Propagate is Base {
     vm.expectRevert(bytes("invalid lengths"));
     _rootManager.propagate(_connectors, _fees, randomEncodedData);
   }
+
+  function test_emitIfAggregateRootPropagated() public {
+    // TODO
+  }
 }
 
 contract RootManager_SendRootToHubs is Base {


### PR DESCRIPTION
- Remove _slowPropagate and _optimisticPropagate
- Create a new and unique `propagate` method
- Deprecated `RootPropagated` and `OpstimiticRootPropagated` events
- Added a new `AggregateRootPropagated` event that will require some changes on the off-chain agent. The off-chain agent will have to be able to determinate if an `aggregate root` it was optimistic or not using the data collected from these two events:
    - ProposedRootFinalized
    - RootsAggregated

CLOSES CON3-6
CLOSES CON3-7