### PR TITLE
fix: removing optimistic mode guard from send

### DIFF
--- a/packages/deployments/contracts/contracts/messaging/connectors/SpokeConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/SpokeConnector.sol
@@ -531,7 +531,6 @@ abstract contract SpokeConnector is Connector, ConnectorManager, WatcherClient, 
    * @param _encodedData Data needed to send crosschain message by associated amb
    */
   function send(bytes memory _encodedData) external payable whenNotPaused rateLimited {
-    if (optimisticMode) revert SpokeConnector_send__OptimisticModeOn();
     bytes32 root = MERKLE.root();
     require(sentMessageRoots[root] == false, "root already sent");
     // mark as sent

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/SpokeConnector.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/SpokeConnector.t.sol
@@ -151,13 +151,6 @@ contract SpokeConnector_General is Base {
     spokeConnector.send(abi.encode(""));
   }
 
-  function test_SpokeConnector__send_failsIfOptimisticModeOn() public {
-    MockSpokeConnector(payable(address(spokeConnector))).setOptimisticMode(true);
-
-    vm.expectRevert(SpokeConnector.SpokeConnector_send__OptimisticModeOn.selector);
-    spokeConnector.send(abi.encode(""));
-  }
-
   function test_SpokeConnector__send_failsIfRootAlreadySent() public {
     bytes32 root = bytes32(bytes("test123"));
     vm.mockCall(address(_merkle), abi.encodeWithSelector(MerkleTreeManager.root.selector), abi.encode(root));


### PR DESCRIPTION
Removing the optimistic check from `send`. The reason is because this forbids the system to work on the state where the spoke connector is in optimistic mode and the root manager is in slow mode.