### PR TITLE
feat: delete pending root on propose

### DIFF
--- a/packages/deployments/contracts/contracts/messaging/connectors/SpokeConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/SpokeConnector.sol
@@ -142,6 +142,12 @@ abstract contract SpokeConnector is Connector, ConnectorManager, WatcherClient, 
   );
 
   /**
+   * @notice Emitted when a pending aggregate root is delete from the mapping
+   * @param aggregateRoot The aggregate root deleted
+   */
+  event PendingAggregateRootDeleted(bytes32 indexed aggregateRoot);
+
+  /**
    * @notice Emitted when the current proposed root is finalized
    * @param aggregateRoot The aggregate root finalized
    */
@@ -607,6 +613,11 @@ abstract contract SpokeConnector is Connector, ConnectorManager, WatcherClient, 
     uint256 _rootTimestamp
   ) external virtual whenNotPaused onlyAllowlistedProposer onlyOptimisticMode {
     if (proposedAggregateRootHash != FINALIZED_HASH) revert SpokeConnector_proposeAggregateRoot__ProposeInProgress();
+    if (pendingAggregateRoots[_aggregateRoot] != 0) {
+      delete pendingAggregateRoots[_aggregateRoot];
+      emit PendingAggregateRootDeleted(_aggregateRoot);
+    }
+
     uint256 _endOfDispute = block.number + disputeBlocks;
     proposedAggregateRootHash = keccak256(abi.encode(_aggregateRoot, _rootTimestamp, _endOfDispute));
 

--- a/packages/deployments/contracts/contracts/messaging/connectors/SpokeConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/SpokeConnector.sol
@@ -142,8 +142,8 @@ abstract contract SpokeConnector is Connector, ConnectorManager, WatcherClient, 
   );
 
   /**
-   * @notice Emitted when a pending aggregate root is delete from the mapping
-   * @param aggregateRoot The aggregate root deleted
+   * @notice Emitted when a pending aggregate root is deleted from the pendingAggregateRoots mapping
+   * @param aggregateRoot The deleted aggregate root
    */
   event PendingAggregateRootDeleted(bytes32 indexed aggregateRoot);
 

--- a/packages/deployments/contracts/contracts/messaging/connectors/mainnet/MainnetSpokeConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/mainnet/MainnetSpokeConnector.sol
@@ -71,7 +71,11 @@ contract MainnetSpokeConnector is SpokeConnector, IHubConnector, IHubSpokeConnec
     if (!optimisticMode) revert MainnetSpokeConnector_saveAggregateRoot__OnlyOptimisticMode();
     if (msg.sender != ROOT_MANAGER) revert MainnetSpokeConnector_saveAggregateRoot__CallerIsNotRootManager();
     if (provenAggregateRoots[_aggregateRoot]) revert MainnetSpokeConnector_saveAggregateRoot__RootAlreadyProven();
-    if (pendingAggregateRoots[_aggregateRoot] != 0) delete pendingAggregateRoots[_aggregateRoot];
+    if (pendingAggregateRoots[_aggregateRoot] != 0) {
+      delete pendingAggregateRoots[_aggregateRoot];
+      emit PendingAggregateRootDeleted(_aggregateRoot);
+    }
+
     provenAggregateRoots[_aggregateRoot] = true;
     emit ProposedRootFinalized(_aggregateRoot);
   }

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/SpokeConnector.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/SpokeConnector.t.sol
@@ -490,6 +490,8 @@ contract SpokeConnector_ProposeAggregateRoot is Base {
     uint32 domain
   );
 
+  event PendingAggregateRootDeleted(bytes32 indexed aggregateRoot);
+
   function setUp() public virtual override {
     super.setUp();
     MockSpokeConnector(payable(address(spokeConnector))).setAllowlistedProposer(_proposer, true);
@@ -530,6 +532,23 @@ contract SpokeConnector_ProposeAggregateRoot is Base {
     vm.expectRevert(
       abi.encodeWithSelector(SpokeConnector.SpokeConnector_proposeAggregateRoot__ProposeInProgress.selector)
     );
+    vm.prank(_proposer);
+    spokeConnector.proposeAggregateRoot(aggregateRoot, rootTimestamp);
+  }
+
+  function test_deletePendingAggregateRoot(bytes32 aggregateRoot, uint256 rootTimestamp) public {
+    vm.assume(aggregateRoot != spokeConnector.FINALIZED_HASH());
+    MockSpokeConnector(payable(address(spokeConnector))).setPendingAggregateRoot(aggregateRoot, block.number);
+    vm.prank(_proposer);
+    spokeConnector.proposeAggregateRoot(aggregateRoot, rootTimestamp);
+    assertEq(spokeConnector.pendingAggregateRoots(aggregateRoot), 0);
+  }
+
+  function test_emitPendingAggregateRootDeleted(bytes32 aggregateRoot, uint256 rootTimestamp) public {
+    vm.assume(aggregateRoot != spokeConnector.FINALIZED_HASH());
+    MockSpokeConnector(payable(address(spokeConnector))).setPendingAggregateRoot(aggregateRoot, block.number);
+    vm.expectEmit(true, true, true, true);
+    emit PendingAggregateRootDeleted(aggregateRoot);
     vm.prank(_proposer);
     spokeConnector.proposeAggregateRoot(aggregateRoot, rootTimestamp);
   }

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/mainnet/MainnetSpokeConnector.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/mainnet/MainnetSpokeConnector.t.sol
@@ -27,6 +27,7 @@ contract MainnetSpokeConnectorForTest is MainnetSpokeConnector {
 contract Base is ConnectorHelper {
   // ============ Events ============
   event ProposedRootFinalized(bytes32 aggregateRoot);
+  event PendingAggregateRootDeleted(bytes32 indexed aggregateRoot);
 
   // ============ Storage ============
   bytes32 outboundRoot = bytes32("test");
@@ -160,7 +161,7 @@ contract MainnetSpokeConnector__saveAggregateRoot is Base {
     assertEq(MainnetSpokeConnectorForTest(_l1Connector).provenAggregateRoots(_aggregateRoot), true);
   }
 
-  function test_MainnetSpokeConnector__saveAggregateRoot_deletesPendingRoot(
+  function test_MainnetSpokeConnector__saveAggregateRoot_deletesPendingRootAndEmitsEvent(
     bytes32 _aggregateRoot,
     uint256 _block
   ) public {
@@ -169,6 +170,8 @@ contract MainnetSpokeConnector__saveAggregateRoot is Base {
     MainnetSpokeConnectorForTest(_l1Connector).setOptimisticMode__forTest(true);
     MainnetSpokeConnectorForTest(_l1Connector).setProvenAggregateRoots__forTest(_aggregateRoot, false);
     MainnetSpokeConnectorForTest(_l1Connector).setPendingAggregateRoots__forTest(_aggregateRoot, _block);
+    vm.expectEmit(true, true, true, true);
+    emit PendingAggregateRootDeleted(_aggregateRoot);
     vm.prank(_rootManager);
     MainnetSpokeConnectorForTest(_l1Connector).saveAggregateRoot(_aggregateRoot);
     assertEq(MainnetSpokeConnectorForTest(_l1Connector).pendingAggregateRoots(_aggregateRoot), 0);


### PR DESCRIPTION
On `proposeAggregateRoot` of Spoke Connector we check if the root being proposed is already in the pending map and delete it to prevent aggregate roots to be on the `pending` and `proven` maps at the same time. 
Currently this is possible if after receiving an aggregate root from the AMB, we switch to Op Mode and off-chain agents propose the same root.
Also added a new `PendingAggregateRootDeleted` event to make it easier for off-chain agents to notice this.

CLOSES CON3-37