### PR TITLE
fix: small fixes

### DIFF
--- a/packages/deployments/contracts/contracts/messaging/connectors/ConnectorsLib.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/ConnectorsLib.sol
@@ -2,14 +2,14 @@
 pragma solidity 0.8.17;
 
 /**
+ * @dev The length in bytes of the root
+ */
+uint256 constant ROOT_LENGTH = 32;
+
+/**
  * @title Library for common functions used by the connectors.
  */
 library ConnectorsLib {
-  /**
-   * @dev The length in bytes of the root
-   */
-  uint256 public constant ROOT_LENGTH = 32;
-
   /**
    * @notice Checks that the message length is equal than 32 bytes
    * @param _data Message data

--- a/packages/deployments/contracts/contracts/messaging/connectors/fuel/FuelHubConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/fuel/FuelHubConnector.sol
@@ -23,11 +23,6 @@ contract FuelHubConnector is HubConnector {
   error FuelHubConnector_OriginSenderIsNotMirror();
 
   /**
-   * @notice Constant used to represent the required length of a message
-   */
-  uint256 public constant MESSAGE_LENGTH = 32;
-
-  /**
    * @notice L1 Fuel Messenge portal
    */
   IFuelMessagePortal public immutable FUEL_MESSAGE_PORTAL;

--- a/packages/deployments/contracts/contracts/messaging/connectors/scroll/BaseScroll.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/scroll/BaseScroll.sol
@@ -12,10 +12,6 @@ abstract contract BaseScroll is GasCap {
    * @notice Constant used to represent the zero value of a message
    */
   uint256 public constant ZERO_MSG_VALUE = 0;
-  /**
-   * @notice Constant used to represent the required length of a message
-   */
-  uint256 public constant MESSAGE_LENGTH = 32;
 
   /**
    * @param _gasCap Gas limit for cross domain message

--- a/packages/deployments/contracts/contracts/messaging/connectors/scroll/ScrollHubConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/scroll/ScrollHubConnector.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.17;
 import {BaseScroll} from "./BaseScroll.sol";
 import {Connector} from "../Connector.sol";
 import {ConnectorsLib} from "../ConnectorsLib.sol";
-
 import {HubConnector} from "../HubConnector.sol";
 import {IL1ScrollMessenger} from "../../interfaces/ambs/scroll/IL1ScrollMessenger.sol";
 import {IRootManager} from "../../interfaces/IRootManager.sol";

--- a/packages/deployments/contracts/contracts/messaging/connectors/scroll/ScrollSpokeConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/scroll/ScrollSpokeConnector.sol
@@ -58,7 +58,7 @@ contract ScrollSpokeConnector is SpokeConnector, BaseScroll {
    * @notice Renounces ownership
    * @dev Should not be able to renounce ownership
    */
-  function renounceOwnership() public virtual override(ProposedOwnable, SpokeConnector) {
+  function renounceOwnership() public pure override(ProposedOwnable, SpokeConnector) {
     revert ScrollSpokeConnector_NotImplementedMethod();
   }
 

--- a/packages/deployments/contracts/contracts/messaging/connectors/sygma/BaseSygma.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/sygma/BaseSygma.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.17;
 
 import {Connector} from "../Connector.sol";
+import {ConnectorsLib, ROOT_LENGTH} from "../ConnectorsLib.sol";
 import {GasCap} from "../GasCap.sol";
 import {IBridge} from "../../../../contracts/messaging/interfaces/ambs/sygma/IBridge.sol";
 import {ISygmaConnector} from "./interfaces/ISygmaConnector.sol";
@@ -11,10 +12,6 @@ import {ISygmaConnector} from "./interfaces/ISygmaConnector.sol";
  * @notice Contract containing common logic for Sygma connectors
  */
 abstract contract BaseSygma is GasCap {
-  /**
-   * @notice The length in bytes of the root
-   */
-  uint256 public constant ROOT_LENGTH = 32;
   /**
    * @notice The ID of the Sygma's permissionless handler
    */

--- a/packages/deployments/contracts/contracts/messaging/connectors/sygma/SygmaSpokeConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/sygma/SygmaSpokeConnector.sol
@@ -96,7 +96,7 @@ contract SygmaSpokeConnector is SpokeConnector, BaseSygma {
    * @notice Renounces the ownership of the contract
    * @dev This method is not implemented
    */
-  function renounceOwnership() public view override(SpokeConnector, ProposedOwnable) onlyOwner {
+  function renounceOwnership() public pure override(SpokeConnector, ProposedOwnable) {
     revert SygmaSpokeConnector_UnimplementedMethod();
   }
 

--- a/packages/deployments/contracts/contracts/messaging/connectors/taiko/BaseTaiko.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/taiko/BaseTaiko.sol
@@ -9,11 +9,6 @@ import {ISignalService} from "../../interfaces/ambs/taiko/ISignalService.sol";
  */
 abstract contract BaseTaiko {
   /**
-   * @notice The root length in bytes for a message
-   */
-  uint256 public constant ROOT_LENGTH = 32;
-
-  /**
    * @notice Taiko Signal Service address
    */
   ISignalService public immutable TAIKO_SIGNAL_SERVICE;

--- a/packages/deployments/contracts/contracts/messaging/connectors/taiko/TaikoHubConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/taiko/TaikoHubConnector.sol
@@ -74,7 +74,7 @@ contract TaikoHubConnector is HubConnector, BaseTaiko {
    * @dev The signal must be received on the chain
    */
   function _processMessage(bytes memory _data) internal override {
-    if (!_verifySender(AMB)) revert TaikoHubConnector_SenderNotAllowedAgent();
+    if (!_verifySender(msg.sender)) revert TaikoHubConnector_SenderNotAllowedAgent();
     (bool _received, bytes32 _signal) = _verifyAndGetSignal(SPOKE_CHAIN_ID, mirrorConnector, _data);
     if (!_received) revert TaikoHubConnector_SignalNotReceived();
     IRootManager(ROOT_MANAGER).aggregate(MIRROR_DOMAIN, _signal);
@@ -82,10 +82,10 @@ contract TaikoHubConnector is HubConnector, BaseTaiko {
 
   /**
    * @notice Verifies that the origin sender of the cross domain message is the mirror connector
-   * @param _mirrorSender Mirror sender address
+   * @param _sender The sender address
    * @return _isValid True if the origin sender is the mirror connector, otherwise false
    */
-  function _verifySender(address _mirrorSender) internal view override returns (bool _isValid) {
-    _isValid = msg.sender == _mirrorSender;
+  function _verifySender(address _sender) internal view override returns (bool _isValid) {
+    _isValid = _sender == AMB;
   }
 }

--- a/packages/deployments/contracts/contracts/messaging/connectors/taiko/TaikoSpokeConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/taiko/TaikoSpokeConnector.sol
@@ -56,7 +56,7 @@ contract TaikoSpokeConnector is SpokeConnector, BaseTaiko {
    * @notice Renounces ownership
    * @dev Should not be able to renounce ownership
    */
-  function renounceOwnership() public virtual override(SpokeConnector) {
+  function renounceOwnership() public pure override(SpokeConnector) {
     revert TaikoSpokeConnector_NotImplementedMethod();
   }
 

--- a/packages/deployments/contracts/contracts/messaging/connectors/taiko/TaikoSpokeConnector.sol
+++ b/packages/deployments/contracts/contracts/messaging/connectors/taiko/TaikoSpokeConnector.sol
@@ -28,6 +28,7 @@ contract TaikoSpokeConnector is SpokeConnector, BaseTaiko {
    * @notice Thrown when the message is not received on the destination chain yet
    */
   error TaikoSpokeConnector_SignalNotReceived();
+
   /**
    * @notice Thrown when `renounceOwnership` is called
    */
@@ -77,7 +78,7 @@ contract TaikoSpokeConnector is SpokeConnector, BaseTaiko {
    * @dev The signal must be received on the chain
    */
   function _processMessage(bytes memory _data) internal override {
-    if (!_verifySender(AMB)) revert TaikoSpokeConnector_SenderNotAllowedAgent();
+    if (!_verifySender(msg.sender)) revert TaikoSpokeConnector_SenderNotAllowedAgent();
     (bool _received, bytes32 _signal) = _verifyAndGetSignal(HUB_CHAIN_ID, mirrorConnector, _data);
     if (!_received) revert TaikoSpokeConnector_SignalNotReceived();
     receiveAggregateRoot(_signal);
@@ -85,10 +86,10 @@ contract TaikoSpokeConnector is SpokeConnector, BaseTaiko {
 
   /**
    * @notice Verifies that the origin sender of the cross domain message is the mirror connector
-   * @param _mirrorSender Mirror sender address
-   * @return _isValid True if the origin sender is the mirror connector, otherwise false
+   * @param _sender The sender address
+   * @return _isValid True if the origin sender is allowed off-chain agent (declared as AMB), false otherwise
    */
-  function _verifySender(address _mirrorSender) internal view override returns (bool _isValid) {
-    _isValid = msg.sender == _mirrorSender;
+  function _verifySender(address _sender) internal view override returns (bool _isValid) {
+    _isValid = _sender == AMB;
   }
 }

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/fuel/unit/FuelHubConnector.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/fuel/unit/FuelHubConnector.t.sol
@@ -179,20 +179,26 @@ contract Unit_Connector_FuelHubConnector_ProcessMessage is Base {
 }
 
 contract Unit_Connector_FuelHubConnector_VerifySender is Base {
-  /**
-   * @notice Tests that reverts when the origin sender is not the mirror connector
-   * @param _originSender The origin sender address
-   * @param _mirrorConnector The mirror connector address
-   */
-  function test_returnFalseIfSenderNotMirror(address _originSender, address _mirrorConnector) public {
-    vm.assume(_originSender != _mirrorConnector);
-
+  modifier happyPath(address _mirrorConnector, address _originSender) {
+    vm.assume(_mirrorConnector != _originSender);
     // Mock `messageSender` call on Fuel Messenger Portal and expect it to be called with the correct arguments
     _mockAndExpect(
       _amb,
       abi.encodeWithSelector(IFuelMessagePortal.messageSender.selector),
       abi.encode(_mirrorConnector)
     );
+    _;
+  }
+
+  /**
+   * @notice Tests that reverts when the origin sender is not the mirror connector
+   * @param _originSender The origin sender address
+   * @param _mirrorConnector The mirror connector address
+   */
+  function test_returnFalseIfSenderNotMirror(
+    address _mirrorConnector,
+    address _originSender
+  ) public happyPath(_mirrorConnector, _originSender) {
     assertEq(fuelHubConnector.forTest_verifySender(_originSender), false);
   }
 
@@ -200,13 +206,10 @@ contract Unit_Connector_FuelHubConnector_VerifySender is Base {
    * @notice Tests that returns true when the origin sender is the mirror connector
    * @param _mirrorConnector The mirror connector address
    */
-  function test_returnTrueIfSenderIsMirror(address _mirrorConnector) public {
-    // Mock `messageSender` call on Fuel Messenger Portal and expect it to be called with the correct arguments
-    _mockAndExpect(
-      _amb,
-      abi.encodeWithSelector(IFuelMessagePortal.messageSender.selector),
-      abi.encode(_mirrorConnector)
-    );
+  function test_returnTrueIfSenderIsMirror(
+    address _mirrorConnector,
+    address _originSender
+  ) public happyPath(_mirrorConnector, _originSender) {
     assertEq(fuelHubConnector.forTest_verifySender(_mirrorConnector), true);
   }
 }

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/fuel/unit/FuelHubConnector.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/fuel/unit/FuelHubConnector.t.sol
@@ -179,26 +179,20 @@ contract Unit_Connector_FuelHubConnector_ProcessMessage is Base {
 }
 
 contract Unit_Connector_FuelHubConnector_VerifySender is Base {
-  modifier happyPath(address _mirrorConnector) {
+  /**
+   * @notice Tests that reverts when the origin sender is not the mirror connector
+   * @param _originSender The origin sender address
+   * @param _mirrorConnector The mirror connector address
+   */
+  function test_returnFalseIfSenderNotMirror(address _originSender, address _mirrorConnector) public {
+    vm.assume(_originSender != _mirrorConnector);
+
     // Mock `messageSender` call on Fuel Messenger Portal and expect it to be called with the correct arguments
     _mockAndExpect(
       _amb,
       abi.encodeWithSelector(IFuelMessagePortal.messageSender.selector),
       abi.encode(_mirrorConnector)
     );
-    _;
-  }
-
-  /**
-   * @notice Tests that reverts when the origin sender is not the mirror connector
-   * @param _originSender The origin sender address
-   * @param _mirrorConnector The mirror connector address
-   */
-  function test_returnFalseIfSenderNotMirror(
-    address _originSender,
-    address _mirrorConnector
-  ) public happyPath(_mirrorConnector) {
-    vm.assume(_originSender != _mirrorConnector);
     assertEq(fuelHubConnector.forTest_verifySender(_originSender), false);
   }
 
@@ -206,7 +200,13 @@ contract Unit_Connector_FuelHubConnector_VerifySender is Base {
    * @notice Tests that returns true when the origin sender is the mirror connector
    * @param _mirrorConnector The mirror connector address
    */
-  function test_returnTrueIfSenderIsMirror(address _mirrorConnector) public happyPath(_mirrorConnector) {
+  function test_returnTrueIfSenderIsMirror(address _mirrorConnector) public {
+    // Mock `messageSender` call on Fuel Messenger Portal and expect it to be called with the correct arguments
+    _mockAndExpect(
+      _amb,
+      abi.encodeWithSelector(IFuelMessagePortal.messageSender.selector),
+      abi.encode(_mirrorConnector)
+    );
     assertEq(fuelHubConnector.forTest_verifySender(_mirrorConnector), true);
   }
 }

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/fuel/unit/FuelHubConnector.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/fuel/unit/FuelHubConnector.t.sol
@@ -62,13 +62,6 @@ contract Base is ConnectorHelper {
 
 contract Unit_Connector_FuelHubConnector_Constructor is Base {
   /**
-   * @notice Tests the constant values
-   */
-  function test_constants() public {
-    assertEq(fuelHubConnector.MESSAGE_LENGTH(), ROOT_LENGTH);
-  }
-
-  /**
    * @notice Tests the values of the constructor arguments
    */
   function test_checkConstructorArgs() public {

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/scroll/unit/BaseScroll.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/scroll/unit/BaseScroll.t.sol
@@ -37,8 +37,6 @@ contract Unit_Connector_BaseScroll_Constructor is Base {
    */
   function test_constants() public {
     uint256 _expectedZeroMsgValue = 0;
-    uint256 _expectedMessageLength = 32;
     assertEq(baseScroll.ZERO_MSG_VALUE(), _expectedZeroMsgValue);
-    assertEq(baseScroll.MESSAGE_LENGTH(), _expectedMessageLength);
   }
 }

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/sygma/unit/BaseSygma.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/sygma/unit/BaseSygma.t.sol
@@ -49,7 +49,6 @@ contract Unit_Connector_BaseSygma_Constructor is Base {
    */
   function test_constants() public {
     assertEq(baseSygma.PERMISSIONLESS_HANDLER_ID(), _PERMISSIONLESS_HANDLER_ID);
-    assertEq(baseSygma.ROOT_LENGTH(), _ROOT_LENGTH);
     assertEq(baseSygma.ADDRESS_LEN(), _ADDRESS_LEN);
     assertEq(baseSygma.ZERO_ADDRESS(), _ZERO_ADDRESS);
     assertEq(baseSygma.FUNCTION_SIG_LEN(), _FUNCTION_SIG_LEN);

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/sygma/unit/SygmaSpokeConnector.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/sygma/unit/SygmaSpokeConnector.t.sol
@@ -230,13 +230,6 @@ contract Unit_Connector_SygmaSpokeConnector_VerifySender is Base {
 }
 
 contract Unit_Connector_SygmaSpokeConnector_RenounceOwnership is Base {
-  function test_revertIfCallerNotOwner(address _caller) public {
-    vm.assume(_caller != _owner);
-    vm.expectRevert(ProposedOwnable.ProposedOwnable__onlyOwner_notOwner.selector);
-    vm.prank(_caller);
-    sygmaSpokeConnector.renounceOwnership();
-  }
-
   /**
    * @notice Tests it reverts the method is called
    */

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/taiko/unit/BaseTaiko.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/taiko/unit/BaseTaiko.t.sol
@@ -44,13 +44,6 @@ contract Base is ConnectorHelper {
 
 contract Unit_Connector_BaseTaiko_Constructor is Base {
   /**
-   * @notice Tests the values of the constants
-   */
-  function test_constants() public {
-    assertEq(baseTaiko.ROOT_LENGTH(), ROOT_LENGTH);
-  }
-
-  /**
    * @notice Tests the values of the constructor arguments
    */
   function test_checkConstructorArgs() public {

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/taiko/unit/TaikoHubConnector.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/taiko/unit/TaikoHubConnector.t.sol
@@ -213,8 +213,8 @@ contract Unit_Connector_TaikoHubConnector_VerifySender is Base {
    * @notice Tests that returns true if the sender is the expected one
    */
   function test_returnTrue() public {
-    vm.prank(_amb);
-    assertEq(taikoHubConnector.forTest_verifySender(_amb), true);
+    vm.prank(offChainAgent);
+    assertEq(taikoHubConnector.forTest_verifySender(offChainAgent), true);
   }
 
   /**

--- a/packages/deployments/contracts/contracts_forge/messaging/connectors/taiko/unit/TaikoSpokeConnector.t.sol
+++ b/packages/deployments/contracts/contracts_forge/messaging/connectors/taiko/unit/TaikoSpokeConnector.t.sol
@@ -231,8 +231,8 @@ contract Unit_Connector_TaikoSpokeConnector_VerifySender is Base {
    * @notice Tests that returns true if the sender is the expected one
    */
   function test_returnTrue() public {
-    vm.prank(_amb);
-    assertEq(taikoSpokeConnector.forTest_verifySender(_amb), true);
+    vm.prank(offChainAgent);
+    assertEq(taikoSpokeConnector.forTest_verifySender(offChainAgent), true);
   }
 
   /**


### PR DESCRIPTION
* Update the `renounceOwnership()` function visibility to `pure`. Remove `onlyOwner` modifier when is unimplemented
* Remove the `MESSAGE_LENGTH` constant when unused. Imported it from `ConnectorsLib.sol` when needed
* Update `verifySender()` arg on Taiko connectors
* Update unit tests based on the changes
* Remove `happyPath` modifier on Fuel `VerifySender` unit tests