### PR TITLE
chore: undo changes on deploy msg script

### DIFF
--- a/packages/deployments/contracts/deploy/01_deployMessaging.ts
+++ b/packages/deployments/contracts/deploy/01_deployMessaging.ts
@@ -81,8 +81,8 @@ const formatConnectorArgs = (
       delayBlocks: config.delayBlocks,
       merkle: merkleManager,
       watcherManager,
-      minDisputeBlocks: protocol.hub.minDisputeBlocks,
-      disputeBlocks: protocol.hub.disputeBlocks,
+      minDisputeBlocks: config.minDisputeBlocks,
+      disputeBlocks: config.disputeBlocks,
     },
   ];
 

--- a/packages/deployments/contracts/package.json
+++ b/packages/deployments/contracts/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "scripts": {
     "test": "yarn forge test --no-match-path '*/fork/**.sol'",
-    "test:connectors": "yarn forge test --mc Unit_Connector && forge test --mc Integration_Connector",
     "test:upgrade": "ts-node ./src/cli/upgrade/main.ts",
     "test:fork": "yarn forge test --match-path '*/fork/**.sol'",
     "forge": "forge",


### PR DESCRIPTION
Undo changes over not connectors related files to keep them as equal as the files in the Connext monorepo main branch.